### PR TITLE
修复了镜像命名空间增加删除之后不能正常刷新的情况。

### DIFF
--- a/src/pages/Image/NamespaceManagement/NamespacePagination/index.js
+++ b/src/pages/Image/NamespaceManagement/NamespacePagination/index.js
@@ -52,7 +52,13 @@ class NamespacePagination extends Component {
 
     //获取最新数据并刷新
     refreshList(current, searchKey,select) {
-
+        // 如果这三个参数没有接收到，那么使用他们的默认值
+        if(current===undefined)
+            var current = 1;
+        if(searchKey===undefined)
+            var searchKey = "";
+        if(select===undefined)
+            var select = "all";
         let url = API.image + '/v1/projects';
         let _this = this;
 


### PR DESCRIPTION
刷新的函数因为某些原因没能接受到参数。
修复完成后镜像命名空间在增删之后可以正确刷新了，不再报get请求的500错误